### PR TITLE
feat: add support for skipping TLS certificate verfication for warpgate

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,10 @@ terraform {
 provider "warpgate" {
   host  = "https://warpgate.example.com"
   token = var.warpgate_token
+
+  # Optionally disable TLS while connecting to Warpgate
+  # Required only for self-signed certificates
+  insecure_skip_verify = true
 }
 
 # Create a role
@@ -96,4 +100,5 @@ The WarpGate provider offers a way to authenticate with the WarpGate API using a
 
 ### Optional
 
+- `insecure_skip_verify` (Bool) Whether to skip the TLS certificate verification (self-signed certificates)
 - `token` (String, Sensitive) API token for authenticating with WarpGate API

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -4,6 +4,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -19,9 +20,10 @@ const (
 
 // Config contains the configuration for the client
 type Config struct {
-	Host    string
-	Token   string
-	Timeout time.Duration
+	Host               string
+	Token              string
+	Timeout            time.Duration
+	InsecureSkipVerify bool
 }
 
 // Client is a Warpgate API client
@@ -53,6 +55,9 @@ func NewClient(cfg *Config) (*Client, error) {
 		token:   cfg.Token,
 		httpClient: &http.Client{
 			Timeout: timeout,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: cfg.InsecureSkipVerify},
+			},
 		},
 	}, nil
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -24,6 +24,12 @@ func New(version string) func() *schema.Provider {
 					DefaultFunc: schema.EnvDefaultFunc("WARPGATE_HOST", nil),
 					Description: "The Warpgate API host URL (e.g., https://warpgate.example.com)",
 				},
+				"insecure_skip_verify": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					DefaultFunc: schema.EnvDefaultFunc("WARPGATE_INSECURE_SKIP_VERIFY", nil),
+					Description: "Whether to skip the TLS certificate verification (self-signed certificates)",
+				},
 				"token": {
 					Type:        schema.TypeString,
 					Optional:    true,
@@ -70,6 +76,7 @@ func configure() func(context.Context, *schema.ResourceData) (any, diag.Diagnost
 
 		host := d.Get("host").(string)
 		token := d.Get("token").(string)
+		insecureSkipVerify := d.Get("insecure_skip_verify").(bool)
 
 		// Ensure the host has the API path
 		apiPath := "/@warpgate/admin/api"
@@ -82,8 +89,9 @@ func configure() func(context.Context, *schema.ResourceData) (any, diag.Diagnost
 		}
 
 		cfg := &client.Config{
-			Host:  host,
-			Token: token,
+			Host:               host,
+			Token:              token,
+			InsecureSkipVerify: insecureSkipVerify,
 		}
 
 		c, err := client.NewClient(cfg)


### PR DESCRIPTION
This allows users to define a flag to disable TLS verification while connecting to WarpGate admin. Useful for connecting to WarpGate instances without TLS or with self-signed certificates

fixes #4 