### PR TITLE
Renaming `provider` to `sso_provider`

### DIFF
--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -60,7 +60,7 @@ In addition to the arguments listed above, the following attributes are exported
   * `postgres` - List of credential types required for PostgreSQL access.
 * `sso_credentials` - List of SSO credentials associated with the user.
   * `id` - The ID of the SSO credential.
-  * `provider` - The SSO provider name (e.g., 'google', 'github', 'okta').
+  * `sso_provider` - The SSO provider name (e.g., 'google', 'github', 'okta').
   * `email` - The email address associated with the SSO provider.
 
 ## Working with Credential Policies
@@ -81,12 +81,12 @@ locals {
   requires_sso        = contains(local.ssh_credentials, "Sso")
 
   # Work with SSO credentials
-  sso_providers = [for cred in data.warpgate_user.eugene.sso_credentials : cred.provider]
+  sso_providers = [for cred in data.warpgate_user.eugene.sso_credentials : cred.sso_provider]
   has_google_sso = contains(local.sso_providers, "google")
   has_github_sso = contains(local.sso_providers, "github")
 
   # Get SSO emails by provider
-  google_emails = [for cred in data.warpgate_user.eugene.sso_credentials : cred.email if cred.provider == "google"]
+  google_emails = [for cred in data.warpgate_user.eugene.sso_credentials : cred.email if cred.sso_provider == "google"]
 }
 ```
 
@@ -121,4 +121,4 @@ Read-Only:
 
 - `email` (String) The email address associated with the SSO provider
 - `id` (String) The ID of the SSO credential
-- `provider` (String) The SSO provider name
+- `sso_provider` (String) The SSO provider name

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -49,13 +49,13 @@ resource "warpgate_user" "sso_user" {
 # Add SSO credentials to the user
 resource "warpgate_user_sso_credential" "google_sso" {
   user_id  = warpgate_user.sso_user.id
-  provider = "google"
+  sso_provider = "google"
   email    = "john.doe@company.com"
 }
 
 resource "warpgate_user_sso_credential" "github_sso" {
   user_id  = warpgate_user.sso_user.id
-  provider = "github"
+  sso_provider = "github"
   email    = "john.doe@company.com"
 }
 ```
@@ -100,7 +100,7 @@ resource "warpgate_user" "sso_user" {
 # Add Google SSO credential
 resource "warpgate_user_sso_credential" "alice_google" {
   user_id  = warpgate_user.sso_user.id
-  provider = "google"
+  sso_provider = "google"
   email    = "alice@company.com"
 }
 ```
@@ -155,4 +155,4 @@ Read-Only:
 
 - `email` (String) The email address associated with the SSO provider
 - `id` (String) The ID of the SSO credential
-- `provider` (String) The SSO provider name
+- `sso_provider` (String) The SSO provider name

--- a/docs/resources/user_sso_credential.md
+++ b/docs/resources/user_sso_credential.md
@@ -28,21 +28,21 @@ resource "warpgate_user" "john_doe" {
 # Add Google SSO credential
 resource "warpgate_user_sso_credential" "john_google" {
   user_id  = warpgate_user.john_doe.id
-  provider = "google"
+  sso_provider = "google"
   email    = "john.doe@company.com"
 }
 
 # Add GitHub SSO credential for the same user
 resource "warpgate_user_sso_credential" "john_github" {
   user_id  = warpgate_user.john_doe.id
-  provider = "github"
+  sso_provider = "github"
   email    = "john.doe@company.com"
 }
 
 # Add Okta SSO credential
 resource "warpgate_user_sso_credential" "john_okta" {
   user_id  = warpgate_user.john_doe.id
-  provider = "okta"
+  sso_provider = "okta"
   email    = "john.doe@company.com"
 }
 ```
@@ -65,14 +65,14 @@ resource "warpgate_user" "multi_sso_user" {
 # Primary corporate SSO
 resource "warpgate_user_sso_credential" "alice_okta" {
   user_id  = warpgate_user.multi_sso_user.id
-  provider = "okta"
+  sso_provider = "okta"
   email    = "alice@company.com"
 }
 
 # Backup SSO for personal projects
 resource "warpgate_user_sso_credential" "alice_google" {
   user_id  = warpgate_user.multi_sso_user.id
-  provider = "google"
+  sso_provider = "google"
   email    = "alice.personal@gmail.com"
 }
 ```
@@ -82,7 +82,7 @@ resource "warpgate_user_sso_credential" "alice_google" {
 The following arguments are supported:
 
 * `user_id` - (Required, Forces new resource) The ID of the user to add the SSO credential to. Changing this forces a new resource to be created.
-* `provider` - (Required) The SSO provider name. Common values include `google`, `github`, `okta`, `azure`, or any custom SAML/OIDC provider configured in WarpGate.
+* `sso_provider` - (Required) The SSO provider name. Common values include `google`, `github`, `okta`, `azure`, or any custom SAML/OIDC provider configured in WarpGate.
 * `email` - (Required) The email address associated with the SSO provider. This should match the email address in the user's SSO provider account.
 
 ## Attribute Reference
@@ -158,7 +158,7 @@ resource "warpgate_user" "service_account" {
 
 resource "warpgate_user_sso_credential" "service_google" {
   user_id  = warpgate_user.service_account.id
-  provider = "google"
+  sso_provider = "google"
   email    = "ci-cd-bot@company.com"
 }
 ```
@@ -197,7 +197,7 @@ resource "warpgate_user" "prod_user" {
 ### Required
 
 - `email` (String) The email address associated with the SSO provider
-- `provider` (String) The SSO provider name (e.g., 'google', 'github', 'okta')
+- `sso_provider` (String) The SSO provider name (e.g., 'google', 'github', 'okta')
 - `user_id` (String) The ID of the user to add the SSO credential to
 
 ### Read-Only

--- a/internal/provider/data_source_user.go
+++ b/internal/provider/data_source_user.go
@@ -78,7 +78,7 @@ func dataSourceUser() *schema.Resource {
 							Computed:    true,
 							Description: "The ID of the SSO credential",
 						},
-						"provider": {
+						"sso_provider": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The SSO provider name",
@@ -106,7 +106,7 @@ func flattenSsoCredentials(credentials []client.SsoCredential) []any {
 	for i, cred := range credentials {
 		result[i] = map[string]any{
 			"id":       cred.ID,
-			"provider": cred.Provider,
+			"sso_provider": cred.Provider,
 			"email":    cred.Email,
 		}
 	}

--- a/internal/provider/resource_user_sso_credential.go
+++ b/internal/provider/resource_user_sso_credential.go
@@ -29,7 +29,7 @@ func resourceUserSsoCredential() *schema.Resource {
 				Description:  "The ID of the user to add the SSO credential to",
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
-			"provider": {
+			"sso_provider": {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "The SSO provider name (e.g., 'google', 'github', 'okta')",
@@ -51,7 +51,7 @@ func resourceUserSsoCredentialCreate(ctx context.Context, d *schema.ResourceData
 	c := providerMeta.client
 
 	userID := d.Get("user_id").(string)
-	provider := d.Get("provider").(string)
+	provider := d.Get("sso_provider").(string)
 	email := d.Get("email").(string)
 
 	// Verify user exists
@@ -104,7 +104,7 @@ func resourceUserSsoCredentialRead(ctx context.Context, d *schema.ResourceData, 
 		return diags
 	}
 
-	if err := d.Set("provider", credential.Provider); err != nil {
+	if err := d.Set("sso_provider", credential.Provider); err != nil {
 		return diag.FromErr(fmt.Errorf("failed to set provider: %w", err))
 	}
 
@@ -122,7 +122,7 @@ func resourceUserSsoCredentialUpdate(ctx context.Context, d *schema.ResourceData
 
 	userID := d.Get("user_id").(string)
 	credentialID := d.Id()
-	provider := d.Get("provider").(string)
+	provider := d.Get("sso_provider").(string)
 	email := d.Get("email").(string)
 
 	_, err := c.UpdateSsoCredential(ctx, userID, credentialID, provider, email)


### PR DESCRIPTION
`provider` is not a valid key for resources. so we rename it to `sso_provider` to remove the conflict.

The planning is failing with the following error:

```
tofu plan 
╷
│ Error: InternalValidate
│ 
│   with provider["registry.terraform.io/warp-tech/warpgate"],
│   on providers.tf line 19, in provider "warpgate":
│   19: provider "warpgate" {
│ 
│ Internal validation of the provider failed! This is always a bug
│ with the provider itself, and not a user issue. Please report
│ this bug:
│ 
│ resource warpgate_user_sso_credential: provider is a reserved field name
╵
```

And the terraform sdk source code includes `provider` as a reserved name:

https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/schema/resource.go#L19