### PR TITLE
feat(target): add postgres protocol version

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,10 +204,11 @@ resource "warpgate_target" "postgres_db" {
   description = "Production PostgreSQL Database"
 
   postgres_options {
-    host     = "postgres.example.com"
-    port     = 5432
-    username = "admin"
-    password = var.postgres_password
+    host             = "postgres.example.com"
+    port             = 5432
+    username         = "admin"
+    protocol_version = "3.0"
+    password         = var.postgres_password
     tls {
       mode   = "Required"
       verify = true

--- a/docs/data-sources/target.md
+++ b/docs/data-sources/target.md
@@ -119,6 +119,7 @@ Based on the target type, one of the following option blocks will be populated:
   - `host` - The PostgreSQL server hostname or IP address.
   - `port` - The PostgreSQL server port.
   - `username` - The PostgreSQL username.
+  - `protocol_version` - The PostgreSQL protocol version requested by the target.
   - `password` - The PostgreSQL password.
   - `tls` - TLS configuration.
     - `mode` - TLS mode (Disabled, Preferred, Required).
@@ -240,6 +241,7 @@ Read-Only:
 - `host` (String)
 - `password` (String)
 - `port` (Number)
+- `protocol_version` (String)
 - `tls` (List of Object) (see [below for nested schema](#nestedobjatt--postgres_options--tls))
 - `username` (String)
 

--- a/docs/resources/target.md
+++ b/docs/resources/target.md
@@ -86,10 +86,11 @@ resource "warpgate_target" "postgres_db" {
   description = "Analytics PostgreSQL database"
 
   postgres_options {
-    host     = "analytics-db.example.com"
-    port     = 5432
-    username = "analyst"
-    password = "dbpassword"
+    host             = "analytics-db.example.com"
+    port             = 5432
+    username         = "analyst"
+    protocol_version = "3.0"
+    password         = "dbpassword"
     tls {
       mode   = "Required"
       verify = true
@@ -181,6 +182,7 @@ One of the following option blocks must be specified:
   * `host` - (Required) The PostgreSQL server hostname or IP address.
   * `port` - (Required) The PostgreSQL server port.
   * `username` - (Required) The PostgreSQL username.
+  * `protocol_version` - (Optional) The PostgreSQL protocol version to request. Valid values: `3.0`, `3.2`.
   * `password` - (Optional) The PostgreSQL password.
   * `tls` - (Required) TLS configuration block.
     * `mode` - (Required) TLS mode. Valid values: `Disabled`, `Preferred`, `Required`.
@@ -323,6 +325,7 @@ Required:
 Optional:
 
 - `password` (String, Sensitive) The PostgreSQL password
+- `protocol_version` (String) The PostgreSQL protocol version to request. Valid values: 3.0, 3.2
 
 <a id="nestedblock--postgres_options--tls"></a>
 ### Nested Schema for `postgres_options.tls`

--- a/internal/client/target.go
+++ b/internal/client/target.go
@@ -84,12 +84,13 @@ type TargetMySQLOptions struct {
 
 // TargetPostgresOptions represents options for PostgreSQL targets
 type TargetPostgresOptions struct {
-	Kind     string `json:"kind"`
-	Host     string `json:"host"`
-	Port     int    `json:"port"`
-	Username string `json:"username"`
-	Password string `json:"password,omitempty"`
-	TLS      TLS    `json:"tls"`
+	Kind            string `json:"kind"`
+	Host            string `json:"host"`
+	Port            int    `json:"port"`
+	Username        string `json:"username"`
+	ProtocolVersion string `json:"protocol_version,omitempty"`
+	Password        string `json:"password,omitempty"`
+	TLS             TLS    `json:"tls"`
 }
 
 // KubernetesTargetAuth is a wrapper for the different Kubernetes authentication methods

--- a/internal/provider/data_source_target.go
+++ b/internal/provider/data_source_target.go
@@ -220,6 +220,11 @@ func dataSourceTarget() *schema.Resource {
 							Computed:    true,
 							Description: "The PostgreSQL username",
 						},
+						"protocol_version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The PostgreSQL protocol version requested by the target",
+						},
 						"password": {
 							Type:        schema.TypeString,
 							Computed:    true,

--- a/internal/provider/resource_target.go
+++ b/internal/provider/resource_target.go
@@ -238,6 +238,12 @@ func resourceTarget() *schema.Resource {
 							Required:    true,
 							Description: "The PostgreSQL username",
 						},
+						"protocol_version": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"3.0", "3.2"}, false),
+							Description:  "The PostgreSQL protocol version to request. Valid values: 3.0, 3.2",
+						},
 						"password": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -650,6 +656,11 @@ func buildPostgresTargetOptions(opts map[string]any) (*client.TargetPostgresOpti
 	port := opts["port"].(int)
 	username := opts["username"].(string)
 
+	var protocolVersion string
+	if v, ok := opts["protocol_version"]; ok {
+		protocolVersion = v.(string)
+	}
+
 	var password string
 	if v, ok := opts["password"]; ok {
 		password = v.(string)
@@ -666,12 +677,13 @@ func buildPostgresTargetOptions(opts map[string]any) (*client.TargetPostgresOpti
 	}
 
 	return &client.TargetPostgresOptions{
-		Kind:     "Postgres",
-		Host:     host,
-		Port:     port,
-		Username: username,
-		Password: password,
-		TLS:      tls,
+		Kind:            "Postgres",
+		Host:            host,
+		Port:            port,
+		Username:        username,
+		ProtocolVersion: protocolVersion,
+		Password:        password,
+		TLS:             tls,
 	}, nil
 }
 
@@ -864,6 +876,10 @@ func setTargetOptions(d *schema.ResourceData, options any) error {
 			"port":     optionsMap["port"],
 			"username": optionsMap["username"],
 			"tls":      []any{tlsOpts},
+		}
+
+		if protocolVersion, ok := optionsMap["protocol_version"].(string); ok && protocolVersion != "" {
+			pgOpts["protocol_version"] = protocolVersion
 		}
 
 		if password, ok := optionsMap["password"].(string); ok && password != "" {

--- a/internal/provider/resource_target_test.go
+++ b/internal/provider/resource_target_test.go
@@ -1,0 +1,60 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/warp-tech/terraform-provider-warpgate/internal/client"
+)
+
+func TestBuildPostgresTargetOptionsWithProtocolVersion(t *testing.T) {
+	opts, err := buildPostgresTargetOptions(map[string]any{
+		"host":             "postgres.example.com",
+		"port":             5432,
+		"username":         "admin",
+		"protocol_version": "3.0",
+		"password":         "secret",
+		"tls": []any{
+			map[string]any{
+				"mode":   "Required",
+				"verify": true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildPostgresTargetOptions returned error: %v", err)
+	}
+
+	if opts.ProtocolVersion != "3.0" {
+		t.Fatalf("expected protocol version 3.0, got %q", opts.ProtocolVersion)
+	}
+}
+
+func TestSetTargetOptionsWithPostgresProtocolVersion(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceTarget().Schema, map[string]any{})
+	err := setTargetOptions(d, &client.TargetPostgresOptions{
+		Kind:            "Postgres",
+		Host:            "postgres.example.com",
+		Port:            5432,
+		Username:        "admin",
+		ProtocolVersion: "3.2",
+		Password:        "secret",
+		TLS: client.TLS{
+			Mode:   client.TLSModeRequired,
+			Verify: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("setTargetOptions returned error: %v", err)
+	}
+
+	postgresOptions := d.Get("postgres_options").([]any)
+	if len(postgresOptions) != 1 {
+		t.Fatalf("expected one postgres_options block, got %d", len(postgresOptions))
+	}
+
+	opts := postgresOptions[0].(map[string]any)
+	if got := opts["protocol_version"]; got != "3.2" {
+		t.Fatalf("expected protocol version 3.2, got %v", got)
+	}
+}

--- a/templates/data-sources/target.md.tmpl
+++ b/templates/data-sources/target.md.tmpl
@@ -119,6 +119,7 @@ Based on the target type, one of the following option blocks will be populated:
   - `host` - The PostgreSQL server hostname or IP address.
   - `port` - The PostgreSQL server port.
   - `username` - The PostgreSQL username.
+  - `protocol_version` - The PostgreSQL protocol version requested by the target.
   - `password` - The PostgreSQL password.
   - `tls` - TLS configuration.
     - `mode` - TLS mode (Disabled, Preferred, Required).

--- a/templates/resources/target.md.tmpl
+++ b/templates/resources/target.md.tmpl
@@ -86,10 +86,11 @@ resource "warpgate_target" "postgres_db" {
   description = "Analytics PostgreSQL database"
 
   postgres_options {
-    host     = "analytics-db.example.com"
-    port     = 5432
-    username = "analyst"
-    password = "dbpassword"
+    host             = "analytics-db.example.com"
+    port             = 5432
+    username         = "analyst"
+    protocol_version = "3.0"
+    password         = "dbpassword"
     tls {
       mode   = "Required"
       verify = true
@@ -181,6 +182,7 @@ One of the following option blocks must be specified:
   * `host` - (Required) The PostgreSQL server hostname or IP address.
   * `port` - (Required) The PostgreSQL server port.
   * `username` - (Required) The PostgreSQL username.
+  * `protocol_version` - (Optional) The PostgreSQL protocol version to request. Valid values: `3.0`, `3.2`.
   * `password` - (Optional) The PostgreSQL password.
   * `tls` - (Required) TLS configuration block.
     * `mode` - (Required) TLS mode. Valid values: `Disabled`, `Preferred`, `Required`.


### PR DESCRIPTION
## Description

Adds `protocol_version` to `warpgate_target.postgres_options` so PostgreSQL targets can explicitly request Warpgate protocol version `3.0` or `3.2`.

The field is optional and is sent to the Warpgate API as `protocol_version`. If it is not set, the provider keeps the current behavior and omits the field from the request.

This is useful for PostgreSQL-compatible services or proxies that require a specific protocol version.

!!! Implemented with AI assistance (Codex), then reviewed and tested locally.

## Changes

- Add `protocol_version` to PostgreSQL target resource schema
- Validate allowed values: `3.0`, `3.2`
- Pass the value to Warpgate API as `protocol_version`
- Read `protocol_version` back into Terraform state/data source
- Update README, templates, and generated docs
- Add unit tests for PostgreSQL target expand/flatten behavior

## Tests

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `git diff --check`
- `go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-name warpgate`