### PR TITLE
feat(target): add postgres default database name

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,11 +204,12 @@ resource "warpgate_target" "postgres_db" {
   description = "Production PostgreSQL Database"
 
   postgres_options {
-    host             = "postgres.example.com"
-    port             = 5432
-    username         = "admin"
-    protocol_version = "3.0"
-    password         = var.postgres_password
+    host                  = "postgres.example.com"
+    port                  = 5432
+    username              = "admin"
+    default_database_name = "app_db"
+    protocol_version      = "3.0"
+    password              = var.postgres_password
     tls {
       mode   = "Required"
       verify = true

--- a/docs/data-sources/target.md
+++ b/docs/data-sources/target.md
@@ -120,6 +120,7 @@ Based on the target type, one of the following option blocks will be populated:
   - `host` - The PostgreSQL server hostname or IP address.
   - `port` - The PostgreSQL server port.
   - `username` - The PostgreSQL username.
+  - `default_database_name` - The default PostgreSQL database name to connect to.
   - `protocol_version` - The PostgreSQL protocol version requested by the target.
   - `password` - The PostgreSQL password.
   - `tls` - TLS configuration.
@@ -240,6 +241,7 @@ Read-Only:
 
 Read-Only:
 
+- `default_database_name` (String)
 - `host` (String)
 - `password` (String)
 - `port` (Number)

--- a/docs/resources/target.md
+++ b/docs/resources/target.md
@@ -87,11 +87,12 @@ resource "warpgate_target" "postgres_db" {
   description = "Analytics PostgreSQL database"
 
   postgres_options {
-    host             = "analytics-db.example.com"
-    port             = 5432
-    username         = "analyst"
-    protocol_version = "3.0"
-    password         = "dbpassword"
+    host                  = "analytics-db.example.com"
+    port                  = 5432
+    username              = "analyst"
+    default_database_name = "app_db"
+    protocol_version      = "3.0"
+    password              = "dbpassword"
     tls {
       mode   = "Required"
       verify = true
@@ -184,6 +185,7 @@ One of the following option blocks must be specified:
   * `host` - (Required) The PostgreSQL server hostname or IP address.
   * `port` - (Required) The PostgreSQL server port.
   * `username` - (Required) The PostgreSQL username.
+  * `default_database_name` - (Optional) The default PostgreSQL database name to connect to.
   * `protocol_version` - (Optional) The PostgreSQL protocol version to request. Valid values: `3.0`, `3.2`.
   * `password` - (Optional) The PostgreSQL password.
   * `tls` - (Required) TLS configuration block.
@@ -327,6 +329,7 @@ Required:
 
 Optional:
 
+- `default_database_name` (String) The default PostgreSQL database name to connect to
 - `password` (String, Sensitive) The PostgreSQL password
 - `protocol_version` (String) The PostgreSQL protocol version to request. Valid values: 3.0, 3.2
 

--- a/internal/client/target.go
+++ b/internal/client/target.go
@@ -85,13 +85,14 @@ type TargetMySQLOptions struct {
 
 // TargetPostgresOptions represents options for PostgreSQL targets
 type TargetPostgresOptions struct {
-	Kind            string `json:"kind"`
-	Host            string `json:"host"`
-	Port            int    `json:"port"`
-	Username        string `json:"username"`
-	ProtocolVersion string `json:"protocol_version,omitempty"`
-	Password        string `json:"password,omitempty"`
-	TLS             TLS    `json:"tls"`
+	Kind                string `json:"kind"`
+	Host                string `json:"host"`
+	Port                int    `json:"port"`
+	Username            string `json:"username"`
+	DefaultDatabaseName string `json:"default_database_name,omitempty"`
+	ProtocolVersion     string `json:"protocol_version,omitempty"`
+	Password            string `json:"password,omitempty"`
+	TLS                 TLS    `json:"tls"`
 }
 
 // KubernetesTargetAuth is a wrapper for the different Kubernetes authentication methods

--- a/internal/provider/data_source_target.go
+++ b/internal/provider/data_source_target.go
@@ -225,6 +225,11 @@ func dataSourceTarget() *schema.Resource {
 							Computed:    true,
 							Description: "The PostgreSQL username",
 						},
+						"default_database_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The default PostgreSQL database name to connect to",
+						},
 						"protocol_version": {
 							Type:        schema.TypeString,
 							Computed:    true,

--- a/internal/provider/resource_target.go
+++ b/internal/provider/resource_target.go
@@ -245,6 +245,11 @@ func resourceTarget() *schema.Resource {
 							Required:    true,
 							Description: "The PostgreSQL username",
 						},
+						"default_database_name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The default PostgreSQL database name to connect to",
+						},
 						"protocol_version": {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -659,6 +664,11 @@ func buildPostgresTargetOptions(opts map[string]any) (*client.TargetPostgresOpti
 	port := opts["port"].(int)
 	username := opts["username"].(string)
 
+	var defaultDatabaseName string
+	if v, ok := opts["default_database_name"]; ok {
+		defaultDatabaseName = v.(string)
+	}
+
 	var protocolVersion string
 	if v, ok := opts["protocol_version"]; ok {
 		protocolVersion = v.(string)
@@ -680,13 +690,14 @@ func buildPostgresTargetOptions(opts map[string]any) (*client.TargetPostgresOpti
 	}
 
 	return &client.TargetPostgresOptions{
-		Kind:            "Postgres",
-		Host:            host,
-		Port:            port,
-		Username:        username,
-		ProtocolVersion: protocolVersion,
-		Password:        password,
-		TLS:             tls,
+		Kind:                "Postgres",
+		Host:                host,
+		Port:                port,
+		Username:            username,
+		DefaultDatabaseName: defaultDatabaseName,
+		ProtocolVersion:     protocolVersion,
+		Password:            password,
+		TLS:                 tls,
 	}, nil
 }
 
@@ -879,6 +890,10 @@ func setTargetOptions(d *schema.ResourceData, options any) error {
 			"port":     optionsMap["port"],
 			"username": optionsMap["username"],
 			"tls":      []any{tlsOpts},
+		}
+
+		if defaultDatabaseName, ok := optionsMap["default_database_name"].(string); ok && defaultDatabaseName != "" {
+			pgOpts["default_database_name"] = defaultDatabaseName
 		}
 
 		if protocolVersion, ok := optionsMap["protocol_version"].(string); ok && protocolVersion != "" {

--- a/internal/provider/resource_target_test.go
+++ b/internal/provider/resource_target_test.go
@@ -9,11 +9,12 @@ import (
 
 func TestBuildPostgresTargetOptionsWithProtocolVersion(t *testing.T) {
 	opts, err := buildPostgresTargetOptions(map[string]any{
-		"host":             "postgres.example.com",
-		"port":             5432,
-		"username":         "admin",
-		"protocol_version": "3.0",
-		"password":         "secret",
+		"host":                  "postgres.example.com",
+		"port":                  5432,
+		"username":              "admin",
+		"default_database_name": "app_db",
+		"protocol_version":      "3.0",
+		"password":              "secret",
 		"tls": []any{
 			map[string]any{
 				"mode":   "Required",
@@ -28,17 +29,22 @@ func TestBuildPostgresTargetOptionsWithProtocolVersion(t *testing.T) {
 	if opts.ProtocolVersion != "3.0" {
 		t.Fatalf("expected protocol version 3.0, got %q", opts.ProtocolVersion)
 	}
+
+	if opts.DefaultDatabaseName != "app_db" {
+		t.Fatalf("expected default database name app_db, got %q", opts.DefaultDatabaseName)
+	}
 }
 
 func TestSetTargetOptionsWithPostgresProtocolVersion(t *testing.T) {
 	d := schema.TestResourceDataRaw(t, resourceTarget().Schema, map[string]any{})
 	err := setTargetOptions(d, &client.TargetPostgresOptions{
-		Kind:            "Postgres",
-		Host:            "postgres.example.com",
-		Port:            5432,
-		Username:        "admin",
-		ProtocolVersion: "3.2",
-		Password:        "secret",
+		Kind:                "Postgres",
+		Host:                "postgres.example.com",
+		Port:                5432,
+		Username:            "admin",
+		DefaultDatabaseName: "app_db",
+		ProtocolVersion:     "3.2",
+		Password:            "secret",
 		TLS: client.TLS{
 			Mode:   client.TLSModeRequired,
 			Verify: true,
@@ -54,6 +60,10 @@ func TestSetTargetOptionsWithPostgresProtocolVersion(t *testing.T) {
 	}
 
 	opts := postgresOptions[0].(map[string]any)
+	if got := opts["default_database_name"]; got != "app_db" {
+		t.Fatalf("expected default database name app_db, got %v", got)
+	}
+
 	if got := opts["protocol_version"]; got != "3.2" {
 		t.Fatalf("expected protocol version 3.2, got %v", got)
 	}

--- a/templates/data-sources/target.md.tmpl
+++ b/templates/data-sources/target.md.tmpl
@@ -120,6 +120,7 @@ Based on the target type, one of the following option blocks will be populated:
   - `host` - The PostgreSQL server hostname or IP address.
   - `port` - The PostgreSQL server port.
   - `username` - The PostgreSQL username.
+  - `default_database_name` - The default PostgreSQL database name to connect to.
   - `protocol_version` - The PostgreSQL protocol version requested by the target.
   - `password` - The PostgreSQL password.
   - `tls` - TLS configuration.

--- a/templates/resources/target.md.tmpl
+++ b/templates/resources/target.md.tmpl
@@ -87,11 +87,12 @@ resource "warpgate_target" "postgres_db" {
   description = "Analytics PostgreSQL database"
 
   postgres_options {
-    host             = "analytics-db.example.com"
-    port             = 5432
-    username         = "analyst"
-    protocol_version = "3.0"
-    password         = "dbpassword"
+    host                  = "analytics-db.example.com"
+    port                  = 5432
+    username              = "analyst"
+    default_database_name = "app_db"
+    protocol_version      = "3.0"
+    password              = "dbpassword"
     tls {
       mode   = "Required"
       verify = true
@@ -184,6 +185,7 @@ One of the following option blocks must be specified:
   * `host` - (Required) The PostgreSQL server hostname or IP address.
   * `port` - (Required) The PostgreSQL server port.
   * `username` - (Required) The PostgreSQL username.
+  * `default_database_name` - (Optional) The default PostgreSQL database name to connect to.
   * `protocol_version` - (Optional) The PostgreSQL protocol version to request. Valid values: `3.0`, `3.2`.
   * `password` - (Optional) The PostgreSQL password.
   * `tls` - (Required) TLS configuration block.


### PR DESCRIPTION
Description
Adds default_database_name to warpgate_target.postgres_options so PostgreSQL targets can configure the default database name stored by Warpgate.

The field is optional and is sent to the Warpgate API as default_database_name. If it is not set, the provider keeps the current behavior and omits the field from the request.

This is useful for PostgreSQL targets where Warpgate should keep an explicit default database name for the target configuration.

!!! Implemented with AI assistance (Codex), then reviewed and tested locally.

Changes
Add default_database_name to PostgreSQL target resource schema
Pass the value to Warpgate API as default_database_name
Read default_database_name back into Terraform state/data source
Update README, templates, and generated docs
Add unit tests for PostgreSQL target expand/flatten behavior
Regenerate target data source schema docs with tfplugindocs

Tests
go test ./...
go vet ./...
go build ./...
git diff --check
go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-name warpgate