### PR TITLE
Add new global parameters from 0.26

### DIFF
--- a/docs/resources/parameters.md
+++ b/docs/resources/parameters.md
@@ -18,7 +18,7 @@ resource "warpgate_parameters" "global_settings" {
   ssh_client_auth_publickey           = true
   ssh_client_auth_password            = true
   ssh_client_auth_keyboard_interactive = false
-  minimize_password_login             = false
+  password_login_mode                 = "Enabled"
   ticket_self_service_enabled         = true
   ticket_auto_approve_existing_access = true
   ticket_max_duration_seconds         = 86400
@@ -27,8 +27,35 @@ resource "warpgate_parameters" "global_settings" {
   ticket_request_show_all_targets     = false
   target_click_action                 = "Connect"
   show_session_menu                   = true
+
+  password_policy {
+    min_length        = 12
+    require_uppercase = true
+    require_lowercase = true
+    require_digits    = true
+    require_special   = true
+  }
+
   max_api_token_duration_seconds      = 2592000
   record_scp                          = true
+
+  login_protection_enabled                 = true
+  login_protection_retention_seconds       = 2592000
+  lp_ip_max_attempts                       = 10
+  lp_ip_time_window_seconds                = 300
+  lp_ip_base_block_duration_seconds        = 60
+  lp_ip_block_duration_multiplier          = 2
+  lp_ip_max_block_duration_seconds         = 3600
+  lp_ip_cooldown_reset_seconds             = 86400
+  lp_user_max_attempts                     = 10
+  lp_user_time_window_seconds              = 300
+  lp_user_auto_unlock                      = true
+  lp_user_lockout_duration_seconds         = 900
+  lp_user_exempt_admins                    = true
+  ssh_banner                               = "Authorized access only"
+  web_ssh_enabled                          = true
+  analytics_consent                        = "Off"
+  analytics_normal                         = false
 }
 ```
 
@@ -41,7 +68,7 @@ The following arguments are supported:
 * `ssh_client_auth_publickey` - (Optional) Enable SSH public key authentication for clients.
 * `ssh_client_auth_password` - (Optional) Enable SSH password authentication for clients.
 * `ssh_client_auth_keyboard_interactive` - (Optional) Enable SSH keyboard interactive authentication for clients.
-* `minimize_password_login` - (Optional) Minimize the use of password-based login methods.
+* `password_login_mode` - (Optional) How the password login form is presented on the gateway login page. Allowed values: `Enabled`, `Minimized`, `Disabled`.
 * `ticket_self_service_enabled` - (Optional) Enable ticket self-service.
 * `ticket_auto_approve_existing_access` - (Optional) Automatically approve ticket requests when the requester already has access.
 * `ticket_max_duration_seconds` - (Optional) Maximum ticket duration in seconds.
@@ -49,9 +76,27 @@ The following arguments are supported:
 * `ticket_require_description` - (Optional) Require a description for ticket requests.
 * `ticket_request_show_all_targets` - (Optional) Show all targets when requesting tickets.
 * `target_click_action` - (Optional) Action to take when clicking a target. Allowed values: `Connect`, `ShowInstructions`.
-* `show_session_menu` - (Optional, default: `true`) When enabled, Warpgate injects a session menu into HTTP sessions, allowing users to log out or return to the home page.
+* `show_session_menu` - (Optional) When enabled, Warpgate injects a session menu into HTTP sessions, allowing users to log out or return to the home page.
+* `password_policy` - (Optional) Password policy rules.
 * `max_api_token_duration_seconds` - (Optional) Maximum API token duration in seconds.
 * `record_scp` - (Optional) Record SCP sessions.
+* `login_protection_enabled` - (Optional) Enable login protection.
+* `login_protection_retention_seconds` - (Optional) How long login protection records are retained, in seconds.
+* `lp_ip_max_attempts` - (Optional) Maximum failed login attempts per IP address.
+* `lp_ip_time_window_seconds` - (Optional) Time window for failed login attempts per IP address, in seconds.
+* `lp_ip_base_block_duration_seconds` - (Optional) Base IP block duration in seconds.
+* `lp_ip_block_duration_multiplier` - (Optional) Multiplier applied to repeated IP block durations.
+* `lp_ip_max_block_duration_seconds` - (Optional) Maximum IP block duration in seconds.
+* `lp_ip_cooldown_reset_seconds` - (Optional) Cooldown period before the IP block escalation resets, in seconds.
+* `lp_user_max_attempts` - (Optional) Maximum failed login attempts per user.
+* `lp_user_time_window_seconds` - (Optional) Time window for failed login attempts per user, in seconds.
+* `lp_user_auto_unlock` - (Optional) Automatically unlock users after the lockout duration.
+* `lp_user_lockout_duration_seconds` - (Optional) User lockout duration in seconds.
+* `lp_user_exempt_admins` - (Optional) Exempt administrators from user login protection lockouts.
+* `ssh_banner` - (Optional) Banner shown to SSH clients before authentication.
+* `web_ssh_enabled` - (Optional) Enable web-based SSH sessions.
+* `analytics_consent` - (Optional) Whether the instance reports anonymous usage analytics. Allowed values: `Undecided`, `Off`, `On`.
+* `analytics_normal` - (Optional) Enable the normal analytics payload level.
 
 ## Attribute Reference
 
@@ -76,11 +121,28 @@ $ terraform import warpgate_parameters.global_settings parameters
 
 ### Optional
 
+- `analytics_consent` (String) Whether the instance reports anonymous usage analytics.
+- `analytics_normal` (Boolean) Enable the normal analytics payload level.
+- `login_protection_enabled` (Boolean) Enable login protection.
+- `login_protection_retention_seconds` (Number) How long login protection records are retained, in seconds.
+- `lp_ip_base_block_duration_seconds` (Number) Base IP block duration in seconds.
+- `lp_ip_block_duration_multiplier` (Number) Multiplier applied to repeated IP block durations.
+- `lp_ip_cooldown_reset_seconds` (Number) Cooldown period before the IP block escalation resets, in seconds.
+- `lp_ip_max_attempts` (Number) Maximum failed login attempts per IP address.
+- `lp_ip_max_block_duration_seconds` (Number) Maximum IP block duration in seconds.
+- `lp_ip_time_window_seconds` (Number) Time window for failed login attempts per IP address, in seconds.
+- `lp_user_auto_unlock` (Boolean) Automatically unlock users after the lockout duration.
+- `lp_user_exempt_admins` (Boolean) Exempt administrators from user login protection lockouts.
+- `lp_user_lockout_duration_seconds` (Number) User lockout duration in seconds.
+- `lp_user_max_attempts` (Number) Maximum failed login attempts per user.
+- `lp_user_time_window_seconds` (Number) Time window for failed login attempts per user, in seconds.
 - `max_api_token_duration_seconds` (Number) Maximum API token duration in seconds.
-- `minimize_password_login` (Boolean) When enabled, the username and password fields are hidden behind a link on the login page, with the focus on the SSO buttons.
+- `password_login_mode` (String) How the password login form is presented on the gateway login page.
+- `password_policy` (Block List, Max: 1) Password policy rules. (see [below for nested schema](#nestedblock--password_policy))
 - `rate_limit_bytes_per_second` (Number) Global bandwidth limit
 - `record_scp` (Boolean) Record SCP sessions.
 - `show_session_menu` (Boolean) When enabled, Warpgate injects a session menu into HTTP sessions, allowing users to log out or return to the home page.
+- `ssh_banner` (String) Banner shown to SSH clients before authentication.
 - `ssh_client_auth_keyboard_interactive` (Boolean) Enable SSH keyboard interactive authentication
 - `ssh_client_auth_password` (Boolean) Enable SSH password authentication
 - `ssh_client_auth_publickey` (Boolean) Enable SSH public key authentication
@@ -91,7 +153,19 @@ $ terraform import warpgate_parameters.global_settings parameters
 - `ticket_request_show_all_targets` (Boolean) Show all targets when requesting tickets.
 - `ticket_require_description` (Boolean) Require a description for ticket requests.
 - `ticket_self_service_enabled` (Boolean) Enable ticket self-service.
+- `web_ssh_enabled` (Boolean) Enable web-based SSH sessions.
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--password_policy"></a>
+### Nested Schema for `password_policy`
+
+Optional:
+
+- `min_length` (Number) Minimum number of characters, or 0 for no requirement.
+- `require_digits` (Boolean) Require at least one digit.
+- `require_lowercase` (Boolean) Require at least one lowercase character.
+- `require_special` (Boolean) Require at least one special character.
+- `require_uppercase` (Boolean) Require at least one uppercase character.

--- a/internal/client/parameters.go
+++ b/internal/client/parameters.go
@@ -9,42 +9,87 @@ import (
 
 // ParameterValues represents the global parameters retrieved from Warpgate
 type ParameterValues struct {
-	AllowOwnCredentialManagement     bool   `json:"allow_own_credential_management"`
-	RateLimitBytesPerSecond          int    `json:"rate_limit_bytes_per_second,omitempty"`
-	SSHClientAuthPublickey           bool   `json:"ssh_client_auth_publickey"`
-	SSHClientAuthPassword            bool   `json:"ssh_client_auth_password"`
-	SSHClientAuthKeyboardInteractive bool   `json:"ssh_client_auth_keyboard_interactive"`
-	MinimizePasswordLogin            bool   `json:"minimize_password_login"`
-	TicketSelfServiceEnabled         bool   `json:"ticket_self_service_enabled"`
-	TicketAutoApproveExistingAccess  bool   `json:"ticket_auto_approve_existing_access"`
-	TicketMaxDurationSeconds         int64  `json:"ticket_max_duration_seconds,omitempty"`
-	TicketMaxUses                    int    `json:"ticket_max_uses,omitempty"`
-	TicketRequireDescription         bool   `json:"ticket_require_description"`
-	TicketRequestShowAllTargets      bool   `json:"ticket_request_show_all_targets"`
-	TargetClickAction                string `json:"target_click_action,omitempty"`
-	ShowSessionMenu                  bool   `json:"show_session_menu"`
-	MaxAPITokenDurationSeconds       int64  `json:"max_api_token_duration_seconds,omitempty"`
-	RecordSCP                        bool   `json:"record_scp"`
+	AllowOwnCredentialManagement     bool           `json:"allow_own_credential_management"`
+	RateLimitBytesPerSecond          int            `json:"rate_limit_bytes_per_second,omitempty"`
+	SSHClientAuthPublickey           bool           `json:"ssh_client_auth_publickey"`
+	SSHClientAuthPassword            bool           `json:"ssh_client_auth_password"`
+	SSHClientAuthKeyboardInteractive bool           `json:"ssh_client_auth_keyboard_interactive"`
+	PasswordLoginMode                string         `json:"password_login_mode"`
+	TicketSelfServiceEnabled         bool           `json:"ticket_self_service_enabled"`
+	TicketAutoApproveExistingAccess  bool           `json:"ticket_auto_approve_existing_access"`
+	TicketMaxDurationSeconds         int64          `json:"ticket_max_duration_seconds,omitempty"`
+	TicketMaxUses                    int            `json:"ticket_max_uses,omitempty"`
+	TicketRequireDescription         bool           `json:"ticket_require_description"`
+	TicketRequestShowAllTargets      bool           `json:"ticket_request_show_all_targets"`
+	TargetClickAction                string         `json:"target_click_action,omitempty"`
+	ShowSessionMenu                  bool           `json:"show_session_menu"`
+	PasswordPolicy                   PasswordPolicy `json:"password_policy"`
+	MaxAPITokenDurationSeconds       int64          `json:"max_api_token_duration_seconds,omitempty"`
+	RecordSCP                        bool           `json:"record_scp"`
+	LoginProtectionEnabled           bool           `json:"login_protection_enabled"`
+	LoginProtectionRetentionSeconds  int            `json:"login_protection_retention_seconds"`
+	LPIPMaxAttempts                  int            `json:"lp_ip_max_attempts"`
+	LPIPTimeWindowSeconds            int            `json:"lp_ip_time_window_seconds"`
+	LPIPBaseBlockDurationSeconds     int            `json:"lp_ip_base_block_duration_seconds"`
+	LPIPBlockDurationMultiplier      float64        `json:"lp_ip_block_duration_multiplier"`
+	LPIPMaxBlockDurationSeconds      int            `json:"lp_ip_max_block_duration_seconds"`
+	LPIPCooldownResetSeconds         int            `json:"lp_ip_cooldown_reset_seconds"`
+	LPUserMaxAttempts                int            `json:"lp_user_max_attempts"`
+	LPUserTimeWindowSeconds          int            `json:"lp_user_time_window_seconds"`
+	LPUserAutoUnlock                 bool           `json:"lp_user_auto_unlock"`
+	LPUserLockoutDurationSeconds     int            `json:"lp_user_lockout_duration_seconds"`
+	LPUserExemptAdmins               bool           `json:"lp_user_exempt_admins"`
+	SSHBanner                        string         `json:"ssh_banner"`
+	WebSSHEnabled                    bool           `json:"web_ssh_enabled"`
+	AnalyticsConsent                 string         `json:"analytics_consent"`
+	AnalyticsNormal                  bool           `json:"analytics_normal"`
+}
+
+// PasswordPolicy represents the Warpgate password policy settings.
+type PasswordPolicy struct {
+	MinLength        int  `json:"min_length"`
+	RequireUppercase bool `json:"require_uppercase"`
+	RequireLowercase bool `json:"require_lowercase"`
+	RequireDigits    bool `json:"require_digits"`
+	RequireSpecial   bool `json:"require_special"`
 }
 
 // ParametersUpdateRequest is the request payload for updating parameters
 type ParametersUpdateRequest struct {
-	AllowOwnCredentialManagement     bool   `json:"allow_own_credential_management"`
-	RateLimitBytesPerSecond          int    `json:"rate_limit_bytes_per_second,omitempty"`
-	SSHClientAuthPublickey           bool   `json:"ssh_client_auth_publickey"`
-	SSHClientAuthPassword            bool   `json:"ssh_client_auth_password"`
-	SSHClientAuthKeyboardInteractive bool   `json:"ssh_client_auth_keyboard_interactive"`
-	MinimizePasswordLogin            bool   `json:"minimize_password_login"`
-	TicketSelfServiceEnabled         bool   `json:"ticket_self_service_enabled"`
-	TicketAutoApproveExistingAccess  bool   `json:"ticket_auto_approve_existing_access"`
-	TicketMaxDurationSeconds         int64  `json:"ticket_max_duration_seconds,omitempty"`
-	TicketMaxUses                    int    `json:"ticket_max_uses,omitempty"`
-	TicketRequireDescription         bool   `json:"ticket_require_description"`
-	TicketRequestShowAllTargets      bool   `json:"ticket_request_show_all_targets"`
-	TargetClickAction                string `json:"target_click_action,omitempty"`
-	ShowSessionMenu                  bool   `json:"show_session_menu"`
-	MaxAPITokenDurationSeconds       int64  `json:"max_api_token_duration_seconds,omitempty"`
-	RecordSCP                        bool   `json:"record_scp"`
+	AllowOwnCredentialManagement     bool            `json:"allow_own_credential_management"`
+	RateLimitBytesPerSecond          *int            `json:"rate_limit_bytes_per_second,omitempty"`
+	SSHClientAuthPublickey           *bool           `json:"ssh_client_auth_publickey,omitempty"`
+	SSHClientAuthPassword            *bool           `json:"ssh_client_auth_password,omitempty"`
+	SSHClientAuthKeyboardInteractive *bool           `json:"ssh_client_auth_keyboard_interactive,omitempty"`
+	PasswordLoginMode                *string         `json:"password_login_mode,omitempty"`
+	TicketSelfServiceEnabled         *bool           `json:"ticket_self_service_enabled,omitempty"`
+	TicketAutoApproveExistingAccess  *bool           `json:"ticket_auto_approve_existing_access,omitempty"`
+	TicketMaxDurationSeconds         *int64          `json:"ticket_max_duration_seconds,omitempty"`
+	TicketMaxUses                    *int            `json:"ticket_max_uses,omitempty"`
+	TicketRequireDescription         *bool           `json:"ticket_require_description,omitempty"`
+	TicketRequestShowAllTargets      *bool           `json:"ticket_request_show_all_targets,omitempty"`
+	TargetClickAction                *string         `json:"target_click_action,omitempty"`
+	ShowSessionMenu                  *bool           `json:"show_session_menu,omitempty"`
+	PasswordPolicy                   *PasswordPolicy `json:"password_policy,omitempty"`
+	MaxAPITokenDurationSeconds       *int64          `json:"max_api_token_duration_seconds,omitempty"`
+	RecordSCP                        *bool           `json:"record_scp,omitempty"`
+	LoginProtectionEnabled           *bool           `json:"login_protection_enabled,omitempty"`
+	LoginProtectionRetentionSeconds  *int            `json:"login_protection_retention_seconds,omitempty"`
+	LPIPMaxAttempts                  *int            `json:"lp_ip_max_attempts,omitempty"`
+	LPIPTimeWindowSeconds            *int            `json:"lp_ip_time_window_seconds,omitempty"`
+	LPIPBaseBlockDurationSeconds     *int            `json:"lp_ip_base_block_duration_seconds,omitempty"`
+	LPIPBlockDurationMultiplier      *float64        `json:"lp_ip_block_duration_multiplier,omitempty"`
+	LPIPMaxBlockDurationSeconds      *int            `json:"lp_ip_max_block_duration_seconds,omitempty"`
+	LPIPCooldownResetSeconds         *int            `json:"lp_ip_cooldown_reset_seconds,omitempty"`
+	LPUserMaxAttempts                *int            `json:"lp_user_max_attempts,omitempty"`
+	LPUserTimeWindowSeconds          *int            `json:"lp_user_time_window_seconds,omitempty"`
+	LPUserAutoUnlock                 *bool           `json:"lp_user_auto_unlock,omitempty"`
+	LPUserLockoutDurationSeconds     *int            `json:"lp_user_lockout_duration_seconds,omitempty"`
+	LPUserExemptAdmins               *bool           `json:"lp_user_exempt_admins,omitempty"`
+	SSHBanner                        *string         `json:"ssh_banner,omitempty"`
+	WebSSHEnabled                    *bool           `json:"web_ssh_enabled,omitempty"`
+	AnalyticsConsent                 *string         `json:"analytics_consent,omitempty"`
+	AnalyticsNormal                  *bool           `json:"analytics_normal,omitempty"`
 }
 
 // GetParameters retrieves the global parameters from Warpgate

--- a/internal/provider/resource_parameters.go
+++ b/internal/provider/resource_parameters.go
@@ -11,6 +11,8 @@ import (
 )
 
 func resourceParameters() *schema.Resource {
+	intAtLeastZero := validation.ToDiagFunc(validation.IntAtLeast(0))
+
 	return &schema.Resource{
 		CreateContext: resourceParametersCreate,
 		ReadContext:   resourceParametersRead,
@@ -27,7 +29,7 @@ func resourceParameters() *schema.Resource {
 			},
 			"rate_limit_bytes_per_second": optionalIntParameter(
 				"Global bandwidth limit",
-				validation.IntAtLeast(0),
+				intAtLeastZero,
 			),
 			"ssh_client_auth_publickey": {
 				Type:        schema.TypeBool,
@@ -68,11 +70,11 @@ func resourceParameters() *schema.Resource {
 			},
 			"ticket_max_duration_seconds": optionalIntParameter(
 				"Maximum ticket duration in seconds.",
-				validation.IntAtLeast(0),
+				intAtLeastZero,
 			),
 			"ticket_max_uses": optionalIntParameter(
 				"Maximum number of uses for tickets.",
-				validation.IntBetween(0, 32767),
+				validation.ToDiagFunc(validation.IntBetween(0, 32767)),
 			),
 			"ticket_require_description": {
 				Type:        schema.TypeBool,
@@ -109,7 +111,7 @@ func resourceParameters() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"min_length": optionalIntParameter(
 							"Minimum number of characters, or 0 for no requirement.",
-							validation.IntAtLeast(0),
+							intAtLeastZero,
 						),
 						"require_uppercase": optionalComputedBoolParameter("Require at least one uppercase character."),
 						"require_lowercase": optionalComputedBoolParameter("Require at least one lowercase character."),
@@ -120,7 +122,7 @@ func resourceParameters() *schema.Resource {
 			},
 			"max_api_token_duration_seconds": optionalIntParameter(
 				"Maximum API token duration in seconds.",
-				validation.IntAtLeast(0),
+				intAtLeastZero,
 			),
 			"record_scp": optionalComputedBoolParameter("Record SCP sessions."),
 			"login_protection_enabled": optionalComputedBoolParameter(
@@ -128,19 +130,19 @@ func resourceParameters() *schema.Resource {
 			),
 			"login_protection_retention_seconds": optionalIntParameter(
 				"How long login protection records are retained, in seconds.",
-				validation.IntAtLeast(0),
+				intAtLeastZero,
 			),
 			"lp_ip_max_attempts": optionalIntParameter(
 				"Maximum failed login attempts per IP address.",
-				validation.IntAtLeast(0),
+				intAtLeastZero,
 			),
 			"lp_ip_time_window_seconds": optionalIntParameter(
 				"Time window for failed login attempts per IP address, in seconds.",
-				validation.IntAtLeast(0),
+				intAtLeastZero,
 			),
 			"lp_ip_base_block_duration_seconds": optionalIntParameter(
 				"Base IP block duration in seconds.",
-				validation.IntAtLeast(0),
+				intAtLeastZero,
 			),
 			"lp_ip_block_duration_multiplier": {
 				Type:         schema.TypeFloat,
@@ -151,26 +153,26 @@ func resourceParameters() *schema.Resource {
 			},
 			"lp_ip_max_block_duration_seconds": optionalIntParameter(
 				"Maximum IP block duration in seconds.",
-				validation.IntAtLeast(0),
+				intAtLeastZero,
 			),
 			"lp_ip_cooldown_reset_seconds": optionalIntParameter(
 				"Cooldown period before the IP block escalation resets, in seconds.",
-				validation.IntAtLeast(0),
+				intAtLeastZero,
 			),
 			"lp_user_max_attempts": optionalIntParameter(
 				"Maximum failed login attempts per user.",
-				validation.IntAtLeast(0),
+				intAtLeastZero,
 			),
 			"lp_user_time_window_seconds": optionalIntParameter(
 				"Time window for failed login attempts per user, in seconds.",
-				validation.IntAtLeast(0),
+				intAtLeastZero,
 			),
 			"lp_user_auto_unlock": optionalComputedBoolParameter(
 				"Automatically unlock users after the lockout duration.",
 			),
 			"lp_user_lockout_duration_seconds": optionalIntParameter(
 				"User lockout duration in seconds.",
-				validation.IntAtLeast(0),
+				intAtLeastZero,
 			),
 			"lp_user_exempt_admins": optionalComputedBoolParameter(
 				"Exempt administrators from user login protection lockouts.",
@@ -207,13 +209,13 @@ func optionalComputedBoolParameter(description string) *schema.Schema {
 	}
 }
 
-func optionalIntParameter(description string, validateFunc schema.SchemaValidateFunc) *schema.Schema {
+func optionalIntParameter(description string, validateFunc schema.SchemaValidateDiagFunc) *schema.Schema {
 	return &schema.Schema{
-		Type:         schema.TypeInt,
-		Optional:     true,
-		Computed:     true,
-		Description:  description,
-		ValidateFunc: validateFunc,
+		Type:             schema.TypeInt,
+		Optional:         true,
+		Computed:         true,
+		Description:      description,
+		ValidateDiagFunc: validateFunc,
 	}
 }
 

--- a/internal/provider/resource_parameters.go
+++ b/internal/provider/resource_parameters.go
@@ -10,7 +10,6 @@ import (
 	"github.com/warp-tech/terraform-provider-warpgate/internal/client"
 )
 
-// TEST
 func resourceParameters() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceParametersCreate,
@@ -26,84 +25,195 @@ func resourceParameters() *schema.Resource {
 				Required:    true,
 				Description: "Allow users to manage their own credentials",
 			},
-			"rate_limit_bytes_per_second": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "Global bandwidth limit",
-			},
+			"rate_limit_bytes_per_second": optionalIntParameter(
+				"Global bandwidth limit",
+				validation.IntAtLeast(0),
+			),
 			"ssh_client_auth_publickey": {
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Computed:    true,
 				Description: "Enable SSH public key authentication",
 			},
 			"ssh_client_auth_password": {
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Computed:    true,
 				Description: "Enable SSH password authentication",
 			},
 			"ssh_client_auth_keyboard_interactive": {
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Computed:    true,
 				Description: "Enable SSH keyboard interactive authentication",
 			},
-			"minimize_password_login": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "When enabled, the username and password fields are hidden behind a link on the login page, with the focus on the SSO buttons.",
+			"password_login_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				Description:  "How the password login form is presented on the gateway login page.",
+				ValidateFunc: validation.StringInSlice([]string{"Enabled", "Minimized", "Disabled"}, false),
 			},
 			"ticket_self_service_enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Computed:    true,
 				Description: "Enable ticket self-service.",
 			},
 			"ticket_auto_approve_existing_access": {
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Computed:    true,
 				Description: "Automatically approve ticket requests when the requester already has access.",
 			},
-			"ticket_max_duration_seconds": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "Maximum ticket duration in seconds.",
-			},
-			"ticket_max_uses": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "Maximum number of uses for tickets.",
-			},
+			"ticket_max_duration_seconds": optionalIntParameter(
+				"Maximum ticket duration in seconds.",
+				validation.IntAtLeast(0),
+			),
+			"ticket_max_uses": optionalIntParameter(
+				"Maximum number of uses for tickets.",
+				validation.IntBetween(0, 32767),
+			),
 			"ticket_require_description": {
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Computed:    true,
 				Description: "Require a description for ticket requests.",
 			},
 			"ticket_request_show_all_targets": {
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Computed:    true,
 				Description: "Show all targets when requesting tickets.",
 			},
 			"target_click_action": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				Description:  "Action to take when clicking a target.",
 				ValidateFunc: validation.StringInSlice([]string{"Connect", "ShowInstructions"}, false),
 			},
 			"show_session_menu": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     true,
+				Computed:    true,
 				Description: "When enabled, Warpgate injects a session menu into HTTP sessions, allowing users to log out or return to the home page.",
 			},
-			"max_api_token_duration_seconds": {
-				Type:        schema.TypeInt,
+			"password_policy": {
+				Type:        schema.TypeList,
 				Optional:    true,
-				Description: "Maximum API token duration in seconds.",
+				Computed:    true,
+				MaxItems:    1,
+				Description: "Password policy rules.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"min_length": optionalIntParameter(
+							"Minimum number of characters, or 0 for no requirement.",
+							validation.IntAtLeast(0),
+						),
+						"require_uppercase": optionalComputedBoolParameter("Require at least one uppercase character."),
+						"require_lowercase": optionalComputedBoolParameter("Require at least one lowercase character."),
+						"require_digits":    optionalComputedBoolParameter("Require at least one digit."),
+						"require_special":   optionalComputedBoolParameter("Require at least one special character."),
+					},
+				},
 			},
-			"record_scp": {
-				Type:        schema.TypeBool,
+			"max_api_token_duration_seconds": optionalIntParameter(
+				"Maximum API token duration in seconds.",
+				validation.IntAtLeast(0),
+			),
+			"record_scp": optionalComputedBoolParameter("Record SCP sessions."),
+			"login_protection_enabled": optionalComputedBoolParameter(
+				"Enable login protection.",
+			),
+			"login_protection_retention_seconds": optionalIntParameter(
+				"How long login protection records are retained, in seconds.",
+				validation.IntAtLeast(0),
+			),
+			"lp_ip_max_attempts": optionalIntParameter(
+				"Maximum failed login attempts per IP address.",
+				validation.IntAtLeast(0),
+			),
+			"lp_ip_time_window_seconds": optionalIntParameter(
+				"Time window for failed login attempts per IP address, in seconds.",
+				validation.IntAtLeast(0),
+			),
+			"lp_ip_base_block_duration_seconds": optionalIntParameter(
+				"Base IP block duration in seconds.",
+				validation.IntAtLeast(0),
+			),
+			"lp_ip_block_duration_multiplier": {
+				Type:         schema.TypeFloat,
+				Optional:     true,
+				Computed:     true,
+				Description:  "Multiplier applied to repeated IP block durations.",
+				ValidateFunc: validation.FloatAtLeast(0),
+			},
+			"lp_ip_max_block_duration_seconds": optionalIntParameter(
+				"Maximum IP block duration in seconds.",
+				validation.IntAtLeast(0),
+			),
+			"lp_ip_cooldown_reset_seconds": optionalIntParameter(
+				"Cooldown period before the IP block escalation resets, in seconds.",
+				validation.IntAtLeast(0),
+			),
+			"lp_user_max_attempts": optionalIntParameter(
+				"Maximum failed login attempts per user.",
+				validation.IntAtLeast(0),
+			),
+			"lp_user_time_window_seconds": optionalIntParameter(
+				"Time window for failed login attempts per user, in seconds.",
+				validation.IntAtLeast(0),
+			),
+			"lp_user_auto_unlock": optionalComputedBoolParameter(
+				"Automatically unlock users after the lockout duration.",
+			),
+			"lp_user_lockout_duration_seconds": optionalIntParameter(
+				"User lockout duration in seconds.",
+				validation.IntAtLeast(0),
+			),
+			"lp_user_exempt_admins": optionalComputedBoolParameter(
+				"Exempt administrators from user login protection lockouts.",
+			),
+			"ssh_banner": {
+				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Record SCP sessions.",
+				Computed:    true,
+				Description: "Banner shown to SSH clients before authentication.",
 			},
+			"web_ssh_enabled": optionalComputedBoolParameter(
+				"Enable web-based SSH sessions.",
+			),
+			"analytics_consent": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				Description:  "Whether the instance reports anonymous usage analytics.",
+				ValidateFunc: validation.StringInSlice([]string{"Undecided", "Off", "On"}, false),
+			},
+			"analytics_normal": optionalComputedBoolParameter(
+				"Enable the normal analytics payload level.",
+			),
 		},
+	}
+}
+
+func optionalComputedBoolParameter(description string) *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Computed:    true,
+		Description: description,
+	}
+}
+
+func optionalIntParameter(description string, validateFunc schema.SchemaValidateFunc) *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeInt,
+		Optional:     true,
+		Computed:     true,
+		Description:  description,
+		ValidateFunc: validateFunc,
 	}
 }
 
@@ -119,7 +229,6 @@ func resourceParametersCreate(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(fmt.Errorf("failed to create parameters: %w", err))
 	}
 
-	// Use a dummy ID for this singleton resource
 	d.SetId("parameters")
 
 	return resourceParametersRead(ctx, d, meta)
@@ -142,71 +251,50 @@ func resourceParametersRead(ctx context.Context, d *schema.ResourceData, meta an
 		return diags
 	}
 
-	// Set dummy ID for singleton resource
 	d.SetId("parameters")
 
-	if err := d.Set("allow_own_credential_management", params.AllowOwnCredentialManagement); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set allow_own_credential_management: %w", err))
-	}
-
-	if err := d.Set("rate_limit_bytes_per_second", params.RateLimitBytesPerSecond); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set rate_limit_bytes_per_second: %w", err))
-	}
-
-	if err := d.Set("ssh_client_auth_publickey", params.SSHClientAuthPublickey); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set ssh_client_auth_publickey: %w", err))
-	}
-
-	if err := d.Set("ssh_client_auth_password", params.SSHClientAuthPassword); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set ssh_client_auth_password: %w", err))
-	}
-
-	if err := d.Set("ssh_client_auth_keyboard_interactive", params.SSHClientAuthKeyboardInteractive); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set ssh_client_auth_keyboard_interactive: %w", err))
-	}
-
-	if err := d.Set("minimize_password_login", params.MinimizePasswordLogin); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set minimize_password_login: %w", err))
-	}
-
-	if err := d.Set("ticket_self_service_enabled", params.TicketSelfServiceEnabled); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set ticket_self_service_enabled: %w", err))
-	}
-
-	if err := d.Set("ticket_auto_approve_existing_access", params.TicketAutoApproveExistingAccess); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set ticket_auto_approve_existing_access: %w", err))
-	}
-
-	if err := d.Set("ticket_max_duration_seconds", int(params.TicketMaxDurationSeconds)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set ticket_max_duration_seconds: %w", err))
-	}
-
-	if err := d.Set("ticket_max_uses", params.TicketMaxUses); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set ticket_max_uses: %w", err))
-	}
-
-	if err := d.Set("ticket_require_description", params.TicketRequireDescription); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set ticket_require_description: %w", err))
-	}
-
-	if err := d.Set("ticket_request_show_all_targets", params.TicketRequestShowAllTargets); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set ticket_request_show_all_targets: %w", err))
-	}
-
-	if err := d.Set("target_click_action", params.TargetClickAction); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set target_click_action: %w", err))
-	}
-
-	if err := d.Set("show_session_menu", params.ShowSessionMenu); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set show_session_menu: %w", err))
-	}
-
-	if err := d.Set("max_api_token_duration_seconds", int(params.MaxAPITokenDurationSeconds)); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set max_api_token_duration_seconds: %w", err))
-	}
-
-	if err := d.Set("record_scp", params.RecordSCP); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to set record_scp: %w", err))
+	for _, field := range []struct {
+		name  string
+		value any
+	}{
+		{"allow_own_credential_management", params.AllowOwnCredentialManagement},
+		{"rate_limit_bytes_per_second", params.RateLimitBytesPerSecond},
+		{"ssh_client_auth_publickey", params.SSHClientAuthPublickey},
+		{"ssh_client_auth_password", params.SSHClientAuthPassword},
+		{"ssh_client_auth_keyboard_interactive", params.SSHClientAuthKeyboardInteractive},
+		{"password_login_mode", params.PasswordLoginMode},
+		{"ticket_self_service_enabled", params.TicketSelfServiceEnabled},
+		{"ticket_auto_approve_existing_access", params.TicketAutoApproveExistingAccess},
+		{"ticket_max_duration_seconds", int(params.TicketMaxDurationSeconds)},
+		{"ticket_max_uses", params.TicketMaxUses},
+		{"ticket_require_description", params.TicketRequireDescription},
+		{"ticket_request_show_all_targets", params.TicketRequestShowAllTargets},
+		{"target_click_action", params.TargetClickAction},
+		{"show_session_menu", params.ShowSessionMenu},
+		{"password_policy", flattenPasswordPolicy(params.PasswordPolicy)},
+		{"max_api_token_duration_seconds", int(params.MaxAPITokenDurationSeconds)},
+		{"record_scp", params.RecordSCP},
+		{"login_protection_enabled", params.LoginProtectionEnabled},
+		{"login_protection_retention_seconds", params.LoginProtectionRetentionSeconds},
+		{"lp_ip_max_attempts", params.LPIPMaxAttempts},
+		{"lp_ip_time_window_seconds", params.LPIPTimeWindowSeconds},
+		{"lp_ip_base_block_duration_seconds", params.LPIPBaseBlockDurationSeconds},
+		{"lp_ip_block_duration_multiplier", params.LPIPBlockDurationMultiplier},
+		{"lp_ip_max_block_duration_seconds", params.LPIPMaxBlockDurationSeconds},
+		{"lp_ip_cooldown_reset_seconds", params.LPIPCooldownResetSeconds},
+		{"lp_user_max_attempts", params.LPUserMaxAttempts},
+		{"lp_user_time_window_seconds", params.LPUserTimeWindowSeconds},
+		{"lp_user_auto_unlock", params.LPUserAutoUnlock},
+		{"lp_user_lockout_duration_seconds", params.LPUserLockoutDurationSeconds},
+		{"lp_user_exempt_admins", params.LPUserExemptAdmins},
+		{"ssh_banner", params.SSHBanner},
+		{"web_ssh_enabled", params.WebSSHEnabled},
+		{"analytics_consent", params.AnalyticsConsent},
+		{"analytics_normal", params.AnalyticsNormal},
+	} {
+		if err := d.Set(field.name, field.value); err != nil {
+			return diag.FromErr(fmt.Errorf("failed to set %s: %w", field.name, err))
+		}
 	}
 
 	return diags
@@ -230,47 +318,85 @@ func resourceParametersUpdate(ctx context.Context, d *schema.ResourceData, meta 
 func expandParametersUpdateRequest(d *schema.ResourceData) *client.ParametersUpdateRequest {
 	req := &client.ParametersUpdateRequest{
 		AllowOwnCredentialManagement:     d.Get("allow_own_credential_management").(bool),
-		SSHClientAuthPublickey:           d.Get("ssh_client_auth_publickey").(bool),
-		SSHClientAuthPassword:            d.Get("ssh_client_auth_password").(bool),
-		SSHClientAuthKeyboardInteractive: d.Get("ssh_client_auth_keyboard_interactive").(bool),
-		MinimizePasswordLogin:            d.Get("minimize_password_login").(bool),
-		TicketSelfServiceEnabled:         d.Get("ticket_self_service_enabled").(bool),
-		TicketAutoApproveExistingAccess:  d.Get("ticket_auto_approve_existing_access").(bool),
-		TicketRequireDescription:         d.Get("ticket_require_description").(bool),
-		TicketRequestShowAllTargets:      d.Get("ticket_request_show_all_targets").(bool),
-		ShowSessionMenu:                  d.Get("show_session_menu").(bool),
-		RecordSCP:                        d.Get("record_scp").(bool),
+		RateLimitBytesPerSecond:          optionalIntPointer(d, "rate_limit_bytes_per_second"),
+		SSHClientAuthPublickey:           optionalBoolPointer(d, "ssh_client_auth_publickey"),
+		SSHClientAuthPassword:            optionalBoolPointer(d, "ssh_client_auth_password"),
+		SSHClientAuthKeyboardInteractive: optionalBoolPointer(d, "ssh_client_auth_keyboard_interactive"),
+		TicketSelfServiceEnabled:         optionalBoolPointer(d, "ticket_self_service_enabled"),
+		TicketAutoApproveExistingAccess:  optionalBoolPointer(d, "ticket_auto_approve_existing_access"),
+		TicketMaxDurationSeconds:         optionalInt64Pointer(d, "ticket_max_duration_seconds"),
+		TicketMaxUses:                    optionalIntPointer(d, "ticket_max_uses"),
+		TicketRequireDescription:         optionalBoolPointer(d, "ticket_require_description"),
+		TicketRequestShowAllTargets:      optionalBoolPointer(d, "ticket_request_show_all_targets"),
+		TargetClickAction:                optionalStringPointer(d, "target_click_action"),
+		ShowSessionMenu:                  optionalBoolPointer(d, "show_session_menu"),
+		PasswordPolicy:                   expandPasswordPolicy(d),
+		MaxAPITokenDurationSeconds:       optionalInt64Pointer(d, "max_api_token_duration_seconds"),
+		RecordSCP:                        optionalBoolPointer(d, "record_scp"),
+		LoginProtectionEnabled:           optionalBoolPointer(d, "login_protection_enabled"),
+		LoginProtectionRetentionSeconds:  optionalIntPointer(d, "login_protection_retention_seconds"),
+		LPIPMaxAttempts:                  optionalIntPointer(d, "lp_ip_max_attempts"),
+		LPIPTimeWindowSeconds:            optionalIntPointer(d, "lp_ip_time_window_seconds"),
+		LPIPBaseBlockDurationSeconds:     optionalIntPointer(d, "lp_ip_base_block_duration_seconds"),
+		LPIPBlockDurationMultiplier:      optionalFloat64Pointer(d, "lp_ip_block_duration_multiplier"),
+		LPIPMaxBlockDurationSeconds:      optionalIntPointer(d, "lp_ip_max_block_duration_seconds"),
+		LPIPCooldownResetSeconds:         optionalIntPointer(d, "lp_ip_cooldown_reset_seconds"),
+		LPUserMaxAttempts:                optionalIntPointer(d, "lp_user_max_attempts"),
+		LPUserTimeWindowSeconds:          optionalIntPointer(d, "lp_user_time_window_seconds"),
+		LPUserAutoUnlock:                 optionalBoolPointer(d, "lp_user_auto_unlock"),
+		LPUserLockoutDurationSeconds:     optionalIntPointer(d, "lp_user_lockout_duration_seconds"),
+		LPUserExemptAdmins:               optionalBoolPointer(d, "lp_user_exempt_admins"),
+		SSHBanner:                        optionalStringPointer(d, "ssh_banner"),
+		WebSSHEnabled:                    optionalBoolPointer(d, "web_ssh_enabled"),
+		AnalyticsConsent:                 optionalStringPointer(d, "analytics_consent"),
+		AnalyticsNormal:                  optionalBoolPointer(d, "analytics_normal"),
 	}
 
-	if rateLimitBytesPerSecond, ok := d.GetOk("rate_limit_bytes_per_second"); ok {
-		req.RateLimitBytesPerSecond = rateLimitBytesPerSecond.(int)
-	}
-
-	if ticketMaxDurationSeconds, ok := d.GetOk("ticket_max_duration_seconds"); ok {
-		req.TicketMaxDurationSeconds = int64(ticketMaxDurationSeconds.(int))
-	}
-
-	if ticketMaxUses, ok := d.GetOk("ticket_max_uses"); ok {
-		req.TicketMaxUses = ticketMaxUses.(int)
-	}
-
-	if targetClickAction, ok := d.GetOk("target_click_action"); ok {
-		req.TargetClickAction = targetClickAction.(string)
-	}
-
-	if maxAPITokenDurationSeconds, ok := d.GetOk("max_api_token_duration_seconds"); ok {
-		req.MaxAPITokenDurationSeconds = int64(maxAPITokenDurationSeconds.(int))
+	if passwordLoginMode := optionalStringPointer(d, "password_login_mode"); passwordLoginMode != nil {
+		req.PasswordLoginMode = passwordLoginMode
 	}
 
 	return req
+}
+
+func flattenPasswordPolicy(policy client.PasswordPolicy) []any {
+	return []any{
+		map[string]any{
+			"min_length":        policy.MinLength,
+			"require_uppercase": policy.RequireUppercase,
+			"require_lowercase": policy.RequireLowercase,
+			"require_digits":    policy.RequireDigits,
+			"require_special":   policy.RequireSpecial,
+		},
+	}
+}
+
+func expandPasswordPolicy(d *schema.ResourceData) *client.PasswordPolicy {
+	if !configuredValueExists(d, "password_policy") {
+		return nil
+	}
+
+	rawPolicies := d.Get("password_policy").([]any)
+	if len(rawPolicies) == 0 || rawPolicies[0] == nil {
+		return nil
+	}
+
+	rawPolicy := rawPolicies[0].(map[string]any)
+
+	return &client.PasswordPolicy{
+		MinLength:        rawPolicy["min_length"].(int),
+		RequireUppercase: rawPolicy["require_uppercase"].(bool),
+		RequireLowercase: rawPolicy["require_lowercase"].(bool),
+		RequireDigits:    rawPolicy["require_digits"].(bool),
+		RequireSpecial:   rawPolicy["require_special"].(bool),
+	}
 }
 
 // resourceParametersDelete handles the deletion of Warpgate parameters
 func resourceParametersDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	// For a global parameters resource, we don't actually delete it from the API
-	// but we remove it from Terraform state
+	// For a global parameters resource, we don't actually delete it from the API.
 	d.SetId("")
 
 	return diags

--- a/internal/provider/schema_helpers.go
+++ b/internal/provider/schema_helpers.go
@@ -16,6 +16,42 @@ func optionalIntPointer(d *schema.ResourceData, key string) *int {
 	return &intValue
 }
 
+func optionalInt64Pointer(d *schema.ResourceData, key string) *int64 {
+	if !configuredValueExists(d, key) {
+		return nil
+	}
+
+	intValue := int64(d.Get(key).(int))
+	return &intValue
+}
+
+func optionalBoolPointer(d *schema.ResourceData, key string) *bool {
+	if !configuredValueExists(d, key) {
+		return nil
+	}
+
+	boolValue := d.Get(key).(bool)
+	return &boolValue
+}
+
+func optionalStringPointer(d *schema.ResourceData, key string) *string {
+	if !configuredValueExists(d, key) {
+		return nil
+	}
+
+	stringValue := d.Get(key).(string)
+	return &stringValue
+}
+
+func optionalFloat64Pointer(d *schema.ResourceData, key string) *float64 {
+	if !configuredValueExists(d, key) {
+		return nil
+	}
+
+	floatValue := d.Get(key).(float64)
+	return &floatValue
+}
+
 func configuredValueExists(d *schema.ResourceData, key string) bool {
 	value, diags := d.GetRawConfigAt(cty.GetAttrPath(key))
 	if diags.HasError() {

--- a/templates/resources/parameters.md.tmpl
+++ b/templates/resources/parameters.md.tmpl
@@ -18,7 +18,7 @@ resource "warpgate_parameters" "global_settings" {
   ssh_client_auth_publickey           = true
   ssh_client_auth_password            = true
   ssh_client_auth_keyboard_interactive = false
-  minimize_password_login             = false
+  password_login_mode                 = "Enabled"
   ticket_self_service_enabled         = true
   ticket_auto_approve_existing_access = true
   ticket_max_duration_seconds         = 86400
@@ -27,8 +27,35 @@ resource "warpgate_parameters" "global_settings" {
   ticket_request_show_all_targets     = false
   target_click_action                 = "Connect"
   show_session_menu                   = true
+
+  password_policy {
+    min_length        = 12
+    require_uppercase = true
+    require_lowercase = true
+    require_digits    = true
+    require_special   = true
+  }
+
   max_api_token_duration_seconds      = 2592000
   record_scp                          = true
+
+  login_protection_enabled                 = true
+  login_protection_retention_seconds       = 2592000
+  lp_ip_max_attempts                       = 10
+  lp_ip_time_window_seconds                = 300
+  lp_ip_base_block_duration_seconds        = 60
+  lp_ip_block_duration_multiplier          = 2
+  lp_ip_max_block_duration_seconds         = 3600
+  lp_ip_cooldown_reset_seconds             = 86400
+  lp_user_max_attempts                     = 10
+  lp_user_time_window_seconds              = 300
+  lp_user_auto_unlock                      = true
+  lp_user_lockout_duration_seconds         = 900
+  lp_user_exempt_admins                    = true
+  ssh_banner                               = "Authorized access only"
+  web_ssh_enabled                          = true
+  analytics_consent                        = "Off"
+  analytics_normal                         = false
 }
 ```
 
@@ -41,7 +68,7 @@ The following arguments are supported:
 * `ssh_client_auth_publickey` - (Optional) Enable SSH public key authentication for clients.
 * `ssh_client_auth_password` - (Optional) Enable SSH password authentication for clients.
 * `ssh_client_auth_keyboard_interactive` - (Optional) Enable SSH keyboard interactive authentication for clients.
-* `minimize_password_login` - (Optional) Minimize the use of password-based login methods.
+* `password_login_mode` - (Optional) How the password login form is presented on the gateway login page. Allowed values: `Enabled`, `Minimized`, `Disabled`.
 * `ticket_self_service_enabled` - (Optional) Enable ticket self-service.
 * `ticket_auto_approve_existing_access` - (Optional) Automatically approve ticket requests when the requester already has access.
 * `ticket_max_duration_seconds` - (Optional) Maximum ticket duration in seconds.
@@ -49,9 +76,27 @@ The following arguments are supported:
 * `ticket_require_description` - (Optional) Require a description for ticket requests.
 * `ticket_request_show_all_targets` - (Optional) Show all targets when requesting tickets.
 * `target_click_action` - (Optional) Action to take when clicking a target. Allowed values: `Connect`, `ShowInstructions`.
-* `show_session_menu` - (Optional, default: `true`) When enabled, Warpgate injects a session menu into HTTP sessions, allowing users to log out or return to the home page.
+* `show_session_menu` - (Optional) When enabled, Warpgate injects a session menu into HTTP sessions, allowing users to log out or return to the home page.
+* `password_policy` - (Optional) Password policy rules.
 * `max_api_token_duration_seconds` - (Optional) Maximum API token duration in seconds.
 * `record_scp` - (Optional) Record SCP sessions.
+* `login_protection_enabled` - (Optional) Enable login protection.
+* `login_protection_retention_seconds` - (Optional) How long login protection records are retained, in seconds.
+* `lp_ip_max_attempts` - (Optional) Maximum failed login attempts per IP address.
+* `lp_ip_time_window_seconds` - (Optional) Time window for failed login attempts per IP address, in seconds.
+* `lp_ip_base_block_duration_seconds` - (Optional) Base IP block duration in seconds.
+* `lp_ip_block_duration_multiplier` - (Optional) Multiplier applied to repeated IP block durations.
+* `lp_ip_max_block_duration_seconds` - (Optional) Maximum IP block duration in seconds.
+* `lp_ip_cooldown_reset_seconds` - (Optional) Cooldown period before the IP block escalation resets, in seconds.
+* `lp_user_max_attempts` - (Optional) Maximum failed login attempts per user.
+* `lp_user_time_window_seconds` - (Optional) Time window for failed login attempts per user, in seconds.
+* `lp_user_auto_unlock` - (Optional) Automatically unlock users after the lockout duration.
+* `lp_user_lockout_duration_seconds` - (Optional) User lockout duration in seconds.
+* `lp_user_exempt_admins` - (Optional) Exempt administrators from user login protection lockouts.
+* `ssh_banner` - (Optional) Banner shown to SSH clients before authentication.
+* `web_ssh_enabled` - (Optional) Enable web-based SSH sessions.
+* `analytics_consent` - (Optional) Whether the instance reports anonymous usage analytics. Allowed values: `Undecided`, `Off`, `On`.
+* `analytics_normal` - (Optional) Enable the normal analytics payload level.
 
 ## Attribute Reference
 


### PR DESCRIPTION
This adds all the global parameters added to Warpgate as of 0.26 that are not yet in the Terraform provider.

Very importantly, this also replaces minimize_password_login with the new password_login_mode. The old option is now broken as Warpgate no longer supports it, so this MR is very important for people who want to use the new Warpgate version.